### PR TITLE
Fix tests by using the serial_test crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ description = "pathmaster is a powerful command-line tool written in Rust for ma
 repository = "https://github.com/jwliles/pathmaster"
 readme = "README.md"
 keywords = ["path", "environment", "configuration", "backup", "restore"]
-categories = ["cli", "system", "shell"]
 
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "pathmaster"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
-author = "Justin Wayne Liles"
+authors = ["Justin Wayne Liles"]
 description = "pathmaster is a powerful command-line tool written in Rust for managing your system's PATH environment variable."
 repository = "https://github.com/jwliles/pathmaster"
 readme = "README.md"
@@ -21,3 +21,4 @@ shellexpand = "2.1.0"
 
 [dev-dependencies]
 tempfile = "3.2.0"
+serial_test = "0.5.0"


### PR DESCRIPTION
Two of the tests keep failing due to Rust running tests concurrently.

Understanding the Failing Tests
1. test_validate_unset_path
Purpose: Verify that when the PATH environment variable is unset, the validate_path function returns empty existing_dirs and missing_dirs.
Failure: The test expects both vectors to be empty but finds that they are not.
2. test_existing_and_missing_mix
Purpose: Check that validate_path correctly separates existing and missing directories when given a mix.
Failure: The test expects specific directories in existing_dirs and missing_dirs, but the actual results differ.

Action Items
1. Add serial_test to dev-dependencies in Cargo.toml.
2. Import serial_test into your test module.
3. Annotate relevant tests with #[serial].
4. Re-run your tests to verify they pass.

This allowed all tests to pass.